### PR TITLE
Add a symlink of socket to /tmp/mysql.sock

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -33,6 +33,12 @@ class mysql {
     require => File[$boxen::config::envdir]
   }
 
+  file { "/tmp/mysql.sock":
+    ensure => link,
+    target => "${mysql::config::datadir}/socket",
+    require => Package['boxen/brews/mysql'],
+  }
+
   $nc = "/usr/bin/nc -z localhost ${mysql::config::port}"
 
   exec { 'wait-for-mysql':

--- a/spec/classes/mysql_spec.rb
+++ b/spec/classes/mysql_spec.rb
@@ -8,4 +8,5 @@ describe 'mysql' do
   it { should include_class('mysql::config') }
   it { should contain_service('com.boxen.mysql').with(:ensure => 'running') }
   it { should contain_exec('init-mysql-db') }
+  it { should contain_file('/tmp/mysql.sock').with(:ensure => 'link', :target => '/opt/boxen/data/mysql/socket') }
 end


### PR DESCRIPTION
If you have a database.yml with localhost, Rails will try to connect
over the socket for Reasons. This adds a symlink to /tmp/mysql.sock so
Rails will JustWork for those cases.
