### PR TITLE
Increase msql max_allowed_packet

### DIFF
--- a/templates/my.cnf.erb
+++ b/templates/my.cnf.erb
@@ -7,3 +7,4 @@ datadir=<%= scope.lookupvar "mysql::config::datadir" %>
 log-error=<%= scope.lookupvar "mysql::config::logerror" %>
 port=<%= scope.lookupvar "mysql::config::port" %>
 socket=<%= scope.lookupvar "mysql::config::socket" %>
+max_allowed_packet=1073741824


### PR DESCRIPTION
On the Halp team we have had a lot of problems importing data from a dump of production without setting max_allowed_packet=1073741824 in templates/my.cnf.erb
