### PR TITLE
Fix syntax error in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ In config/database.yml:
     ENV["BOXEN_MYSQL_SOCKET"],
     "/var/run/mysql5/mysqld.sock",
     "/tmp/mysql.sock"
-  ].detect { |f| f && File.exist? f }
+  ].detect { |f| f && File.exist?(f) }
 
   port = ENV["BOXEN_MYSQL_PORT"] || "3306"
 %>


### PR DESCRIPTION
The current code will cause syntax error since it is equivalent to `(f && File.exist?) f`
