### PR TITLE
allow launchctl to stop mysql quickly

### DIFF
--- a/templates/dev.mysql.plist.erb
+++ b/templates/dev.mysql.plist.erb
@@ -28,6 +28,9 @@
 
     <key>KeepAlive</key>
     <true />
+    
+    <key>ExitTimeOut</key>
+    <integer>1</integer>
 
     <key>UserName</key>
     <string><%= scope.lookupvar "::luser" %></string>


### PR DESCRIPTION
When launchctl tries to stop a process, it sends INT, waits 20
seconds, and then sends KILL. mysqld happily ignores INT, and just
keeps running until it gets a KILL. That means this patch removes 20
seconds from the shutdown/restart of every machine running mysql via
boxen, which seems like a pretty nice improvement.

I wrote up how I discovered this a while ago:
http://andre.arko.net/2011/08/07/fixing-mac-shutdown-delays/
