### PR TITLE
Import System Timezone Data on Install

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -91,4 +91,13 @@ class mysql {
     timeout     => 30,
     refreshonly => true
   }
+
+  exec { 'mysql-tzinfo-to-sql':
+    command     => "mysql_tzinfo_to_sql /usr/share/zoneinfo | \
+      mysql -u root mysql -P ${mysql::config::port} -S ${mysql::config::socket}",
+    provider    => shell,
+    creates     => "${mysql::config::datadir}/.tz_info_created",
+    subscribe   => Exec['wait-for-mysql'],
+    refreshonly => true
+  }
 }

--- a/spec/classes/mysql_spec.rb
+++ b/spec/classes/mysql_spec.rb
@@ -19,5 +19,7 @@ describe 'mysql' do
     should contain_service('dev.mysql').with(:ensure => 'running')
 
     should contain_exec('init-mysql-db')
+
+    should contain_exec('mysql-tzinfo-to-sql')
   end
 end


### PR DESCRIPTION
Pretty self-explanatory - this change will automatically import system timezone data to MySQL on install.
