### PR TITLE
Grep by word for DB Name

### DIFF
--- a/manifests/db.pp
+++ b/manifests/db.pp
@@ -14,7 +14,7 @@ define mysql::db($ensure = present) {
       creates => "${mysql::config::datadir}/${name}",
       require => Exec['wait-for-mysql'],
       unless  => "mysql -uroot -p13306 -e 'show databases' \
-        --password='' | grep '${name}'"
+        --password='' | grep -w '${name}'"
     }
   } elsif $ensure == 'absent' {
     exec { "delete mysql db ${name}":


### PR DESCRIPTION
Say you create database `foo` and later want to create `foobar`
without `grep -w` the grep will match `foo` and not create `foobar`. With word matching it will.
