### PR TITLE
Fix grants to work with wildcard hosts

### DIFF
--- a/manifests/user/grant.pp
+++ b/manifests/user/grant.pp
@@ -28,7 +28,7 @@ define mysql::user::grant($database,
         -e \"grant ${grants} on ${database}.* to '${username}'@'${host}'; \
         flush privileges;\"",
       require => Exec['wait-for-mysql'],
-      unless  => "mysql -uroot -p13306 -e 'SHOW GRANTS FOR ${username}@${host};' \
+      unless  => "mysql -uroot -p13306 -e 'SHOW GRANTS FOR ${username}@'${host}';' \
         --password='' | grep -w '${database}' | grep -w '${grants}'"
     }
   } elsif $ensure == 'absent' {

--- a/spec/defines/user_grant_spec.rb
+++ b/spec/defines/user_grant_spec.rb
@@ -7,6 +7,8 @@ describe 'mysql::user::grant' do
   let(:title) { 'name' }
   let(:user) { 'user' }
   let(:database) { 'database' }
+  let(:host) { '%' }
+  let(:grants) { 'ALL' }
 
   context "when ensure is present" do
     let(:params) do
@@ -22,6 +24,25 @@ describe 'mysql::user::grant' do
                :command => "mysql -uroot -p13306 --password='' \
         -e \"grant ALL on #{database}.* to '#{user}'@'localhost'; \
         flush privileges;\""
+        )
+    end
+  end
+
+  context "when setting the host" do
+    let(:params) do
+      { :username => user,
+        :database => database,
+        :host     => host }
+    end
+
+    it "properly quotes the host" do
+      should contain_exec("granting #{user} access to #{database}").
+             with(
+               :command => "mysql -uroot -p13306 --password='' \
+        -e \"grant ALL on #{database}.* to '#{user}'@'#{host}'; \
+        flush privileges;\"",
+               :unless  => "mysql -uroot -p13306 -e 'SHOW GRANTS FOR #{user}@'#{host}';' \
+        --password='' | grep -w '#{database}' | grep -w '#{grants}'"
         )
     end
   end


### PR DESCRIPTION
The current grant code fails when using a wildcard host (`%`), because
it's not properly quoted.  Fixed the quoting and wrote a spec for it.
