### PR TITLE
The host is missing from the puppet title

### DIFF
--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -16,7 +16,7 @@ define mysql::user($ensure = present,
   require mysql
 
   if $ensure == 'present' {
-    exec { "create mysql user ${name}":
+    exec { "create mysql user ${name} @ ${host}":
       command => "mysql -uroot -p13306 --password=''\
         -e \"create user '${name}'@'${host}' identified by '${password}';\"",
       require => Exec['wait-for-mysql'],

--- a/manifests/user/grant.pp
+++ b/manifests/user/grant.pp
@@ -23,7 +23,7 @@ define mysql::user::grant($database,
   require mysql
 
   if $ensure == 'present' {
-    exec { "granting ${username} access to ${database}":
+    exec { "granting ${username} access to ${database} @ ${host}":
       command => "mysql -uroot -p13306 --password='' \
         -e \"grant ${grants} on ${database}.* to '${username}'@'${host}'; \
         flush privileges;\"",
@@ -32,7 +32,7 @@ define mysql::user::grant($database,
         --password='' | grep -w '${database}' | grep -w '${grants}'"
     }
   } elsif $ensure == 'absent' {
-    exec { "removing ${username} access to ${database}":
+    exec { "removing ${username} access to ${database} @ ${host}":
       command => "mysql -uroot -p13306 --password='' \
         -e \"REVOKE ALL PRIVILEGES on ${database}.* to '${username}'@'${host}'; \
         flush privileges;\"",

--- a/spec/defines/user_grant_spec.rb
+++ b/spec/defines/user_grant_spec.rb
@@ -19,7 +19,7 @@ describe 'mysql::user::grant' do
     it { should include_class('mysql') }
 
     it "creates the grant" do
-      should contain_exec("granting #{user} access to #{database}").
+      should contain_exec("granting #{user} access to #{database} @ localhost").
              with(
                :command => "mysql -uroot -p13306 --password='' \
         -e \"grant ALL on #{database}.* to '#{user}'@'localhost'; \
@@ -36,7 +36,7 @@ describe 'mysql::user::grant' do
     end
 
     it "properly quotes the host" do
-      should contain_exec("granting #{user} access to #{database}").
+      should contain_exec("granting #{user} access to #{database} @ #{host}").
              with(
                :command => "mysql -uroot -p13306 --password='' \
         -e \"grant ALL on #{database}.* to '#{user}'@'#{host}'; \
@@ -56,10 +56,10 @@ describe 'mysql::user::grant' do
     end
 
     it { should include_class('mysql') }
-    it { should_not contain_exec("granting #{user} access to #{database}") }
+    it { should_not contain_exec("granting #{user} access to #{database} @ #{host}") }
 
     it "revokes the users privs" do
-      should contain_exec("removing #{user} access to #{database}").
+      should contain_exec("removing #{user} access to #{database} @ localhost").
              with(
                :command => "mysql -uroot -p13306 --password='' \
         -e \"REVOKE ALL PRIVILEGES on #{database}.* to '#{user}'@'localhost'; \

--- a/spec/defines/user_spec.rb
+++ b/spec/defines/user_spec.rb
@@ -14,7 +14,7 @@ describe 'mysql::user' do
     it { should include_class('mysql') }
 
     it "creates the user" do
-      should contain_exec("create mysql user #{title}").
+      should contain_exec("create mysql user #{title} @ localhost").
              with(
                :command => "mysql -uroot -p13306 --password=''\
         -e \"create user '#{title}'@'localhost' identified by '';\""


### PR DESCRIPTION
The puppet title is used to define unique resources.  Since `host` is
missing from the title, two declarations with different hosts will be
seen to be the same, and will cause the following puppet error:

```
Error: Duplicate declaration: Exec[granting username access to database] is already declared in file /opt/boxen/repo/shared/mysql/manifests/user/grant.pp:33; cannot redeclare at /opt/boxen/repo/shared/mysql/manifests/user/grant.pp:33 on node ross-mbp.local
```

This commit adds the hostname to the title in both `user.pp` and
`grant.pp`, allowing multiple declarations to succeed.

Note: creating a user differing only in host values is a common mysql
pattern, since a user needs separate grants for logging in from
`localhost` vs. any other host.
