### PR TITLE
Fix mysql::grant on first boxen run

### DIFF
--- a/data/Darwin.yaml
+++ b/data/Darwin.yaml
@@ -3,6 +3,7 @@ mysql::configdir:          "%{::boxen::config::configdir}/mysql"
 mysql::globalconfigprefix: "%{::boxen::config::homebrewdir}"
 mysql::datadir:            "%{::boxen::config::datadir}/mysql"
 mysql::executable:         "%{::boxen::config::homebrewdir}/bin/mysqld_safe"
+mysql::client:             "%{::boxen::config::homebrewdir}/bin/mysql"
 mysql::logdir:             "%{::boxen::config::logdir}/mysql"
 mysql::servicename:        "dev.mysql"
 

--- a/lib/puppet/provider/mysql_grant/default.rb
+++ b/lib/puppet/provider/mysql_grant/default.rb
@@ -46,6 +46,6 @@ Puppet::Type.type(:mysql_grant).provide(:default) do
   end
 
   def mysql(cmd)
-    execute "mysql -u#{@resource[:mysql_user]} -h#{@resource[:mysql_host]} -p#{@resource[:mysql_port]} -u#{@resource[:mysql_user]} -e \"#{cmd}\" --password='#{@resource[:mysql_pass]}'"
+    execute "#{@resource[:executable]} -u#{@resource[:mysql_user]} -h#{@resource[:mysql_host]} -p#{@resource[:mysql_port]} -u#{@resource[:mysql_user]} -e \"#{cmd}\" --password='#{@resource[:mysql_pass]}'"
   end
 end

--- a/lib/puppet/type/mysql_grant.rb
+++ b/lib/puppet/type/mysql_grant.rb
@@ -68,4 +68,8 @@ Puppet::Type.newtype(:mysql_grant) do
   newparam :mysql_port do
     defaultto "3306"
   end
+
+  newparam :executable do
+    defaultto "/opt/boxen/homebrew/bin/mysql"
+  end
 end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,6 +11,7 @@ class mysql(
   $globalconfigprefix = undef,
   $datadir = undef,
   $executable = undef,
+  $client = undef,
   $logdir = undef,
   $servicename = undef,
 
@@ -30,6 +31,7 @@ class mysql(
     $globalconfigprefix,
     $datadir,
     $executable,
+    $client,
     $logdir,
     $servicename,
     $user,

--- a/manifests/user/grant.pp
+++ b/manifests/user/grant.pp
@@ -38,6 +38,7 @@ define mysql::user::grant(
     mysql_pass => '',
     mysql_host => $mysql::host,
     mysql_port => $mysql::port,
+    executable => $mysql::client,
     require    => Exec['wait-for-mysql'],
   }
 }


### PR DESCRIPTION
Fixes #42

`exec` resources have their path setup explicitly, but we're skirting around that in our custom provider. We have to be explicit about where the mysql client executable is.
