### PR TITLE
Interpolate Puppet top-scope variable for datadir

### DIFF
--- a/data/Darwin.yaml
+++ b/data/Darwin.yaml
@@ -11,7 +11,7 @@ mysql::servicename:        "dev.mysql"
 mysql::user: "%{::boxen_user}"
 mysql::host: "127.0.0.1"
 mysql::port: "13306"
-mysql::socket: "%{mysql::datadir}/socket"
+mysql::socket: "%{::boxen::config::datadir}/socket"
 
 mysql::package: boxen/brews/mysql
 mysql::version: 5.5.20-boxen2


### PR DESCRIPTION
When I ran this code, the `socket` configuration line in my.cnf was set
to "socket=/socket".  It turns out that the mysql::socket parameter was
being looked up via Hiera as desired, but '%{mysql::datadir}' was not
being properly expanded.