### PR TITLE
Move plist creation into service class.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -63,11 +63,6 @@ class mysql::config(
     "${boxen::config::envdir}/mysql.sh":
       ensure => absent ;
 
-    '/Library/LaunchDaemons/dev.mysql.plist':
-      content => template('mysql/dev.mysql.plist.erb'),
-      group   => 'wheel',
-      owner   => 'root' ;
-
     "${globalconfigprefix}/var/mysql":
       ensure  => absent,
       force   => true,

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -21,6 +21,15 @@ class mysql::service(
     }
   }
 
+  if $::osfamily == 'Darwin' {
+    file { "/Library/LaunchDaemons/${servicename}.plist":
+      content => template('mysql/dev.mysql.plist.erb'),
+      owner   => 'root',
+      group   => 'wheel',
+      before  => Service['mysql'],
+    }
+  }
+
   $provider = $::osfamily ? {
     'Debian' => 'init',
     default  => undef,

--- a/spec/classes/mysql__config_spec.rb
+++ b/spec/classes/mysql__config_spec.rb
@@ -24,7 +24,5 @@ describe "mysql::config" do
     end
 
     should contain_file("/test/boxen/config/mysql/my.cnf")
-
-    should contain_file('/Library/LaunchDaemons/dev.mysql.plist')
   end
 end


### PR DESCRIPTION
Also ensure that it's created before the service is stopped or started. This avoids some weird timing issues that I've seen in the wild where the server is taken down but doesn't come up again.