### PR TITLE
brews/mysql: fix the datadir to use Boxen's again.

### DIFF
--- a/files/brews/mysql.rb
+++ b/files/brews/mysql.rb
@@ -3,12 +3,6 @@ class Mysql < Formula
   url "https://cdn.mysql.com/Downloads/MySQL-5.6/mysql-5.6.23.tar.gz"
   sha1 "2d610ba01ab97df042d5946ba0da411da5547c5d"
 
-  bottle do
-    sha1 "9edc48cf27c50b6f51bfd90af86716a4a36b39e8" => :yosemite
-    sha1 "e4aee77fd9a4882bd85a718b622fbd817d87e4ae" => :mavericks
-    sha1 "38ef7c81c209fd7ca55f3769c32c9ae593f4384d" => :mountain_lion
-  end
-
   # Fixes compilation with OpenSSL 1.0.2
   # https://bugs.mysql.com/bug.php?id=75623
   patch do
@@ -43,6 +37,10 @@ class Mysql < Formula
     cause "https://github.com/Homebrew/homebrew/issues/issue/144"
   end
 
+  def datadir
+    Pathname.new "/opt/boxen/data/mysql"
+  end
+
   def install
     # Don't hard-code the libtool path. See:
     # https://github.com/Homebrew/homebrew/issues/20185
@@ -60,7 +58,7 @@ class Mysql < Formula
       -DCMAKE_INSTALL_PREFIX=#{prefix}
       -DCMAKE_FIND_FRAMEWORK=LAST
       -DCMAKE_VERBOSE_MAKEFILE=ON
-      -DMYSQL_DATADIR=#{var}/mysql
+      -DMYSQL_DATADIR=#{datadir}
       -DINSTALL_INCLUDEDIR=include/mysql
       -DINSTALL_MANDIR=share/man
       -DINSTALL_DOCDIR=share/doc/#{name}
@@ -133,12 +131,12 @@ class Mysql < Formula
   end
 
   def post_install
-    # Make sure the var/mysql directory exists
-    (var+"mysql").mkpath
-    unless File.exist? "#{var}/mysql/mysql/user.frm"
+    # Make sure the datadir exists
+    datadir.mkpath
+    unless File.exist? "#{datadir}/mysql/user.frm"
       ENV["TMPDIR"] = nil
       system "#{bin}/mysql_install_db", "--verbose", "--user=#{ENV["USER"]}",
-        "--basedir=#{prefix}", "--datadir=#{var}/mysql", "--tmpdir=/tmp"
+        "--basedir=#{prefix}", "--datadir=#{datadir}", "--tmpdir=/tmp"
     end
   end
 
@@ -166,12 +164,12 @@ class Mysql < Formula
       <array>
         <string>#{opt_bin}/mysqld_safe</string>
         <string>--bind-address=127.0.0.1</string>
-        <string>--datadir=#{var}/mysql</string>
+        <string>--datadir=#{datadir}</string>
       </array>
       <key>RunAtLoad</key>
       <true/>
       <key>WorkingDirectory</key>
-      <string>#{var}</string>
+      <string>#{datadir}</string>
     </dict>
     </plist>
     EOS


### PR DESCRIPTION
Also: remove the bottle as it'll use a different datadir. Changed similarly in upstream Homebrew in https://github.com/Homebrew/homebrew/pull/38189.