### PR TITLE
Add MySQL 5.6.23 mirror.

### DIFF
--- a/files/brews/mysql.rb
+++ b/files/brews/mysql.rb
@@ -1,7 +1,8 @@
 class Mysql < Formula
   homepage "https://dev.mysql.com/doc/refman/5.6/en/"
   url "https://cdn.mysql.com/Downloads/MySQL-5.6/mysql-5.6.23.tar.gz"
-  sha1 "2d610ba01ab97df042d5946ba0da411da5547c5d"
+  mirror "http://downloads.sourceforge.net/project/mysql.mirror/MySQL%205.6.23/mysql-5.6.23.tar.gz"
+  sha256 "d04328a00307bb7576429d28130e53b74bb51eacbbfacf26c999c0932b4c98cc"
 
   # Fixes compilation with OpenSSL 1.0.2
   # https://bugs.mysql.com/bug.php?id=75623


### PR DESCRIPTION
Oracle has dropped it from their upstream downloads. Also use `sha256` based on the original tarball just to be extra paranoid about SourceForge.