### PR TITLE
Update MySQL version to 5.6.25 in Darwin.yaml

### DIFF
--- a/data/Darwin.yaml
+++ b/data/Darwin.yaml
@@ -14,4 +14,4 @@ mysql::port: "13306"
 mysql::socket: "%{::boxen::config::datadir}/socket"
 
 mysql::package: boxen/brews/mysql
-mysql::version: 5.6.23
+mysql::version: 5.6.25


### PR DESCRIPTION
I updated our boxen `mysql` module to version 2.1.1. It installed mysql version `5.6.25` when I set up a project with boxen. If I tried to set up another project that also had a mysql dependency I would get this error: 

```
Error: Could not update: Execution of 'brew boxen-upgrade boxen/brews/mysql' returned 1: Error: boxen/brews/mysql 5.6.25 already installed
Wrapped exception:
Execution of 'brew boxen-upgrade boxen/brews/mysql' returned 1: Error: boxen/brews/mysql 5.6.25 already installed
Error: /Stage[main]/Mysql::Package/Package[boxen/brews/mysql]/ensure: change from 5.6.25 to 5.6.23 failed: Could not update: Execution of 'brew boxen-upgrade boxen/brews/mysql' returned 1: Error: boxen/brews/mysql 5.6.25 already installed
```

It looks like `data/Darwin.yaml` still listed version `5.6.23`. I updated it to `5.6.25` and now everything is working as it should.

