### PR TITLE
MySQL 5.6.29

### DIFF
--- a/data/Darwin.yaml
+++ b/data/Darwin.yaml
@@ -14,4 +14,4 @@ mysql::port: "13306"
 mysql::socket: "%{::boxen::config::datadir}/socket"
 
 mysql::package: boxen/brews/mysql
-mysql::version: 5.6.27
+mysql::version: 5.6.29

--- a/files/brews/mysql.rb
+++ b/files/brews/mysql.rb
@@ -1,8 +1,8 @@
 class Mysql < Formula
   desc "Open source relational database management system"
   homepage "https://dev.mysql.com/doc/refman/5.6/en/"
-  url "https://cdn.mysql.com/Downloads/MySQL-5.6/mysql-5.6.27.tar.gz"
-  sha256 "8356bba23f3f6c0c2d4806110c41d1c4d6a4b9c50825e11c5be4bbee2b20b71d"
+  url "https://cdn.mysql.com/Downloads/MySQL-5.6/mysql-5.6.29.tar.gz"
+  sha256 "6ac85b75b2dfa8c232725dda25469df37bf4e48b408cc0978d0dfc34c25a817f"
 
   option :universal
   option "with-tests", "Build with unit tests"


### PR DESCRIPTION
Fixes #74.

Same changes as https://github.com/Homebrew/homebrew-versions/commit/bf5f642f2e909541c137c16f3586c7f25054ef4e.

The current version, 5.6.27, doesn't seem to be available from Oracle's CDN any more:

```
==> Downloading https://cdn.mysql.com/Downloads/MySQL-5.6/mysql-5.6.27.tar.gz
Error: Failed to download resource "mysql"
Download failed: https://cdn.mysql.com/Downloads/MySQL-5.6/mysql-5.6.27.tar.gz
Wrapped exception:
Execution of 'brew boxen-install boxen/brews/mysql' returned 1: ==> Installing mysql from boxen/brews
```