### PR TITLE
MySQL Version 5.6.31

### DIFF
--- a/data/Darwin.yaml
+++ b/data/Darwin.yaml
@@ -14,4 +14,4 @@ mysql::port: "13306"
 mysql::socket: "%{::boxen::config::datadir}/socket"
 
 mysql::package: boxen/brews/mysql
-mysql::version: 5.6.29
+mysql::version: 5.6.31

--- a/files/brews/mysql.rb
+++ b/files/brews/mysql.rb
@@ -1,8 +1,8 @@
 class Mysql < Formula
   desc "Open source relational database management system"
   homepage "https://dev.mysql.com/doc/refman/5.6/en/"
-  url "https://cdn.mysql.com/Downloads/MySQL-5.6/mysql-5.6.29.tar.gz"
-  sha256 "6ac85b75b2dfa8c232725dda25469df37bf4e48b408cc0978d0dfc34c25a817f"
+  url "https://cdn.mysql.com/Downloads/MySQL-5.6/mysql-5.6.31.tar.gz"
+  sha256 "6df1389bbf899025aee6be0f4a12b8b0135e6de7db83e3ea20201ad3633ba424"
 
   option :universal
   option "with-tests", "Build with unit tests"


### PR DESCRIPTION
Looks like the MySQL CDN isn't serving the 5.6.27 URL any more.
I've instead updated to 5.6.31 which is served by the CDN.
