### PR TITLE
Update brew download URL

### DIFF
--- a/files/brews/mysql.rb
+++ b/files/brews/mysql.rb
@@ -1,7 +1,7 @@
 class Mysql < Formula
   desc "Open source relational database management system"
   homepage "https://dev.mysql.com/doc/refman/5.6/en/"
-  url "https://cdn.mysql.com/Downloads/MySQL-5.6/mysql-5.6.29.tar.gz"
+  url "https://dev.mysql.com/Downloads/MySQL-5.6/mysql-5.6.29.tar.gz"
   sha256 "6ac85b75b2dfa8c232725dda25469df37bf4e48b408cc0978d0dfc34c25a817f"
 
   option :universal


### PR DESCRIPTION
The CDN only seems to serve the last two patch releases. Let's use the `dev` URL so these versions can be used long term, without breaking when new versions of MySQL are released.
