### PR TITLE
Ensure my-default.cnf file can be found when initialising databases in High Sierra

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -39,6 +39,11 @@ class mysql::config(
       notify  => Service['mysql'] ;
   }
 
+  file { "${globalconfigprefix}/my-default.cnf":
+    ensure => 'link',
+    target => "${configdir}/my.cnf",
+  }
+
   ->
   exec { 'init-mysql-db':
     command  => "${bindir}/mysql_install_db \


### PR DESCRIPTION
When setting up a new laptop with MacOS High Sierra, I came across the problems described in https://github.com/boxen/puppet-mysql/issues/57.

The solution was to ensure there's a symlink to the my-default.cnf file in one of the search directories listed [here](https://github.com/boxen/puppet-mysql/issues/57#issuecomment-91147053).

I've tested this after `brew uninstall -f mysql`.