### PR TITLE
Updates Homebrew formula to work on Sierra

### DIFF
--- a/files/brews/mysql.rb
+++ b/files/brews/mysql.rb
@@ -37,10 +37,6 @@ class Mysql < Formula
       "COMMAND /usr/bin/libtool -static -o ${TARGET_LOCATION}",
       "COMMAND libtool -static -o ${TARGET_LOCATION}"
 
-    # Build without compiler or CPU specific optimization flags to facilitate
-    # compilation of gems and other software that queries `mysql-config`.
-    ENV.minimal_optimization
-
     # -DINSTALL_* are relative to prefix
     args = %W[
       .

--- a/templates/my.cnf.erb
+++ b/templates/my.cnf.erb
@@ -1,3 +1,6 @@
+[mysqld]
+skip-name-resolve
+
 [client]
 host=<%= @host %>
 port=<%= @port %>


### PR DESCRIPTION
Whilst reinstalling on Sierra, I got a couple of warnings that I've
addressed here. Shouldn't change any functionality but will stop
annoying deprecation messages.