### PR TITLE
Remove deprecated undents

### DIFF
--- a/files/brews/mysql.rb
+++ b/files/brews/mysql.rb
@@ -123,7 +123,7 @@ class Mysql < Formula
     end
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     A "/etc/my.cnf" from another install may interfere with a Homebrew-built
     server starting up correctly.
 
@@ -134,7 +134,7 @@ class Mysql < Formula
 
   plist_options :manual => "mysql.server start"
 
-  def plist; <<-EOS.undent
+  def plist; <<~EOS
     <?xml version="1.0" encoding="UTF-8"?>
     <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
     <plist version="1.0">


### PR DESCRIPTION
Recent versions of Homebrew complain about the undents.

